### PR TITLE
Add emitter field to cheque PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# PDF Service
+
+This FastAPI service generates PDF files for digital cheques. It renders a Jinja2 HTML template and converts it to PDF using WeasyPrint.
+
+## Running the server
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Generating a cheque
+
+Send a POST request to `/cheque` with JSON body:
+
+```json
+{
+  "emitter": "ACME Corp",
+  "payee": "John Doe",
+  "amount": 100.50,
+  "date": "2023-01-01",
+  "cheque_number": "000123"
+}
+```
+
+The service returns the generated PDF document.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI, Response
+from .schemas import ChequeRequest
+from .pdf_utils import render_cheque_pdf
+
+app = FastAPI()
+
+@app.post("/cheque")
+async def generate_cheque(req: ChequeRequest):
+    pdf_bytes = render_cheque_pdf(req.dict())
+    return Response(content=pdf_bytes, media_type="application/pdf")

--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,0 +1,13 @@
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from weasyprint import HTML
+
+env = Environment(
+    loader=FileSystemLoader("templates"),
+    autoescape=select_autoescape(['html', 'xml'])
+)
+
+def render_cheque_pdf(data: dict) -> bytes:
+    template = env.get_template("cheque.html")
+    html_content = template.render(**data)
+    pdf_bytes = HTML(string=html_content).write_pdf()
+    return pdf_bytes

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from datetime import date
+
+class ChequeRequest(BaseModel):
+    emitter: str
+    payee: str
+    amount: float
+    date: date
+    cheque_number: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 weasyprint
 jinja2
+pytest
+httpx

--- a/templates/cheque.html
+++ b/templates/cheque.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+      body { font-family: sans-serif; margin: 0; }
+      .emitter { padding: 20px; }
+      .cheque { border: 1px solid #000; padding: 20px; width: 100%; box-sizing: border-box; }
+    </style>
+</head>
+<body>
+  <div class="emitter">
+    <h3>Émetteur</h3>
+    <p>{{ emitter }}</p>
+  </div>
+  <div class="cheque">
+    <h2>Digital Cheque</h2>
+    <p><strong>Cheque Number:</strong> {{ cheque_number }}</p>
+    <p><strong>Payee:</strong> {{ payee }}</p>
+    <p><strong>Amount:</strong> {{ amount }}</p>
+    <p><strong>Date:</strong> {{ date }}</p>
+  </div>
+</body>
+</html>

--- a/tests/test_cheque.py
+++ b/tests/test_cheque.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import asyncio
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.main import generate_cheque
+from app.schemas import ChequeRequest
+
+
+def test_generate_cheque_pdf():
+    payload = ChequeRequest(
+        emitter="ACME Corp",
+        payee="John Doe",
+        amount=123.45,
+        date="2023-01-01",
+        cheque_number="000123",
+    )
+    response = asyncio.run(generate_cheque(payload))
+    assert response.status_code == 200
+    assert response.media_type == "application/pdf"
+    assert len(response.body) > 0


### PR DESCRIPTION
## Summary
- include emitter info in ChequeRequest schema
- display emitter section above cheque details
- document emitter field in README
- adapt tests for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626e5856c88326acb66b28067860cc